### PR TITLE
Don't error with zero length elem in add_to_last

### DIFF
--- a/R/flowgraph.R
+++ b/R/flowgraph.R
@@ -28,7 +28,11 @@ flowgraph <- function(expr) {
 
   add_to_last <- function(elem, id) {
     w <- which(nodes$id == elem)
-    nodeslast[[w]] <<- c(nodeslast[[w]], id)
+    if (length(w) == 1L) {
+      nodeslast[[w]] <<- c(nodeslast[[w]], id)
+    } else {
+      warning(paste0("elem was '", elem, "' at id '", id, "'"))
+    }
   }
 
   add_edges <- function(...) {


### PR DESCRIPTION
Cf. https://github.com/MangoTheCat/cyclocomp/pull/17

The following expression from **Rmpi** raises an error due to `breaks_tail` seeing a zero length breaks.
```{r}
 function (dellog = TRUE, comm = 1) {
  if (mpi.comm.size(comm) < 2) {
    err <- paste("It seems no slaves running on comm", comm)
    stop(err)
  }
  mpi.bcast.cmd(cmd = break, rank = 0, comm = comm)
  if (.Platform$OS != "windows") {
    if (dellog && mpi.comm.size(0) < mpi.comm.size(comm)) {
      tmp <- paste(Sys.getpid(), "+", comm, sep = "")
      logfile <- paste("*.", tmp, ".*.log", sep = "")
      if (length(system(paste("ls", logfile), TRUE, ignore.stderr = TRUE)) >= 
          1)
        system(paste("rm", logfile))
    }
  }
  if (comm > 0) {
    if (is.loaded("mpi_comm_disconnect")) 
      mpi.comm.disconnect(comm)
    else mpi.comm.free(comm)
  }
}
```