### PR TITLE
Improve performance of `post_process()`

### DIFF
--- a/R/post-process.R
+++ b/R/post-process.R
@@ -13,29 +13,55 @@
 ## are processed again.
 
 post_process <- function(nodes, edges) {
-  e <- 1
-  while (e <= nrow(edges)) {
-    from <- edges$from[e]
-    to <- edges$to[e]
-    rec <- nodes[nodes$id == from, ]
-
-    ## If there is no last sub-block, or the edge edge is going to
-    ## a sub-block, then we are all good. Otherwise rewire.
-    if (length(rec$last[[1]]) && !is_child(to, from)) {
-      edges$from[e] <- rec$last[[1]][1]
-      for (l in rec$last[[1]][-1]) {
-        new_edge <- data.frame(
-          stringsAsFactors = FALSE,
-          from = l,
-          to = to
-        )
-        edges <- rbind(edges[1:e, ], new_edge, edges[-(1:e), ])
-      }
-    } else {
-      e <- e + 1
-    }
+  ## Build an id -> "last" lookup once (hashed environment), instead of
+  ## scanning the whole `nodes` data frame for every edge.
+  last_env <- new.env(parent = emptyenv(), hash = TRUE, size = nrow(nodes) * 2L)
+  ids <- nodes$id
+  lasts <- nodes$last
+  for (i in seq_along(ids)) {
+    assign(ids[i], lasts[[i]], envir = last_env)
   }
-  unique(edges)
+
+  from_all <- edges$from
+  to_all <- edges$to
+  res_from <- vector("list", length(from_all))
+  res_to <- vector("list", length(from_all))
+
+  ## Resolve each edge independently. When the source block has a "last"
+  ## sub-block (and the edge does not go into that block), the edge is
+  ## rewired to leave from the "last" sub-block(s). Each rewired source
+  ## may itself need rewiring, so we iterate with an explicit stack.
+  for (k in seq_along(from_all)) {
+    stack_f <- from_all[k]
+    stack_t <- to_all[k]
+    out_f <- character()
+    out_t <- character()
+    while (length(stack_f)) {
+      f <- stack_f[[1L]]
+      t <- stack_t[[1L]]
+      stack_f <- stack_f[-1L]
+      stack_t <- stack_t[-1L]
+      lst <- last_env[[f]]
+      if (length(lst) && !is_child(t, f)) {
+        stack_f <- c(lst, stack_f)
+        stack_t <- c(rep(t, length(lst)), stack_t)
+      } else {
+        out_f <- c(out_f, f)
+        out_t <- c(out_t, t)
+      }
+    }
+    res_from[[k]] <- out_f
+    res_to[[k]] <- out_t
+  }
+
+  from <- unlist(res_from, use.names = FALSE)
+  to <- unlist(res_to, use.names = FALSE)
+  keep <- !duplicated.default(paste(from, to, sep = "\r"))
+  data.frame(
+    stringsAsFactors = FALSE,
+    from = from[keep],
+    to = to[keep]
+  )
 }
 
 is_child <- function(child, parent) {

--- a/R/post-process.R
+++ b/R/post-process.R
@@ -13,55 +13,34 @@
 ## are processed again.
 
 post_process <- function(nodes, edges) {
-  ## Build an id -> "last" lookup once (hashed environment), instead of
-  ## scanning the whole `nodes` data frame for every edge.
-  last_env <- new.env(parent = emptyenv(), hash = TRUE, size = nrow(nodes) * 2L)
-  ids <- nodes$id
-  lasts <- nodes$last
-  for (i in seq_along(ids)) {
-    assign(ids[i], lasts[[i]], envir = last_env)
-  }
+  ## Look up each node's "last" sub-block by id, instead of rescanning
+  ## the whole `nodes` data frame on every edge.
+  last_by_id <- nodes$last
+  names(last_by_id) <- nodes$id
 
-  from_all <- edges$from
-  to_all <- edges$to
-  res_from <- vector("list", length(from_all))
-  res_to <- vector("list", length(from_all))
+  e <- 1
+  while (e <= nrow(edges)) {
+    from <- edges$from[e]
+    to <- edges$to[e]
+    last <- last_by_id[[from]]
 
-  ## Resolve each edge independently. When the source block has a "last"
-  ## sub-block (and the edge does not go into that block), the edge is
-  ## rewired to leave from the "last" sub-block(s). Each rewired source
-  ## may itself need rewiring, so we iterate with an explicit stack.
-  for (k in seq_along(from_all)) {
-    stack_f <- from_all[k]
-    stack_t <- to_all[k]
-    out_f <- character()
-    out_t <- character()
-    while (length(stack_f)) {
-      f <- stack_f[[1L]]
-      t <- stack_t[[1L]]
-      stack_f <- stack_f[-1L]
-      stack_t <- stack_t[-1L]
-      lst <- last_env[[f]]
-      if (length(lst) && !is_child(t, f)) {
-        stack_f <- c(lst, stack_f)
-        stack_t <- c(rep(t, length(lst)), stack_t)
-      } else {
-        out_f <- c(out_f, f)
-        out_t <- c(out_t, t)
+    ## If there is no last sub-block, or the edge edge is going to
+    ## a sub-block, then we are all good. Otherwise rewire.
+    if (length(last) && !is_child(to, from)) {
+      edges$from[e] <- last[1]
+      for (l in last[-1]) {
+        new_edge <- data.frame(
+          stringsAsFactors = FALSE,
+          from = l,
+          to = to
+        )
+        edges <- rbind(edges[1:e, ], new_edge, edges[-(1:e), ])
       }
+    } else {
+      e <- e + 1
     }
-    res_from[[k]] <- out_f
-    res_to[[k]] <- out_t
   }
-
-  from <- unlist(res_from, use.names = FALSE)
-  to <- unlist(res_to, use.names = FALSE)
-  keep <- !duplicated.default(paste(from, to, sep = "\r"))
-  data.frame(
-    stringsAsFactors = FALSE,
-    from = from[keep],
-    to = to[keep]
-  )
+  unique(edges)
 }
 
 is_child <- function(child, parent) {

--- a/R/post-process.R
+++ b/R/post-process.R
@@ -13,8 +13,8 @@
 ## are processed again.
 
 post_process <- function(nodes, edges) {
-  ## Look up each node's "last" sub-block by id, instead of rescanning
-  ## the whole `nodes` data frame on every edge.
+  # Extract this vector since subsetting it in the while loop is faster than subsetting
+  # from a dataframe.
   last_by_id <- nodes$last
   names(last_by_id) <- nodes$id
 


### PR DESCRIPTION
The benchmarks below use the package [`cross`](https://github.com/davisvaughan/cross):

``` r
cross::bench_versions(pkgs = c("gaborcsardi/cyclocomp", "etiennebacher/cyclocomp@speedup"), {
  bench::mark(cyclocomp::cyclocomp_package("polars"))
})
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 gaborcsardi/cyclocomp     "cyclocom… 5.78s  5.78s     0.173     661MB     7.97
#> 2 etiennebacher/cyclocomp@… "cyclocom… 2.97s  2.97s     0.337     483MB    13.1


cross::bench_versions(pkgs = c("gaborcsardi/cyclocomp", "etiennebacher/cyclocomp@speedup"), {
  bench::mark(cyclocomp::cyclocomp_package("dplyr"))
})
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 gaborcsardi/cyclocomp     "cyclocom…  3.5s   3.5s     0.286     341MB     7.71
#> 2 etiennebacher/cyclocomp@… "cyclocom… 2.73s  2.73s     0.367     192MB    12.1


cross::bench_versions(pkgs = c("gaborcsardi/cyclocomp", "etiennebacher/cyclocomp@speedup"), {
  bench::mark(cyclocomp::cyclocomp_package("lintr"))
})
#> # A tibble: 2 × 7
#>   pkg                       expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <chr>                     <bch:expr> <bch> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 gaborcsardi/cyclocomp     "cyclocom… 4.76s  4.76s     0.210     833MB     5.88
#> 2 etiennebacher/cyclocomp@… "cyclocom… 1.75s  1.75s     0.573     183MB    27.5
```